### PR TITLE
Support local dependency roots for standalone Tax-Data runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,58 @@
 # Tax-Data
 Produces historical and projected tax microdata files 
 
+## Local Standalone Use
+
+`Tax-Data` expects a dependency tree rooted at the paths configured in
+`config/interfaces/output_roots.yaml`. For local or public standalone use, the
+easiest option is to keep all inputs under a single local root and override the
+default cluster paths at runtime with environment variables.
+
+Supported overrides:
+
+- `TAX_DATA_RUNSCRIPT_ID`: runscript name without `.yaml` suffix. Defaults to `baseline`.
+- `TAX_DATA_WRITE_LOCALLY`: overrides `runtime_options.write_locally` from the runscript.
+- `TAX_DATA_USER_ID`: overrides `runtime_options.user_id` from the runscript.
+- `TAX_DATA_LOCAL_ROOT`: replaces `output_roots$local`.
+- `TAX_DATA_PRODUCTION_ROOT`: replaces `output_roots$production`.
+- `TAX_DATA_INPUT_ROOT`: optional explicit root for dependency reads. If unset,
+  inputs are read from the active local/production root for the run.
+
+Example:
+
+```bash
+TAX_DATA_WRITE_LOCALLY=1 \
+TAX_DATA_USER_ID=user_test \
+TAX_DATA_LOCAL_ROOT=/path/to/data/root \
+Rscript src/main.R
+```
+
+The baseline runscript expects dependencies under a directory structure like:
+
+```text
+<root>/
+  raw_data/
+    IRS-PUF/
+      v1/
+        <vintage>/
+          historical/
+            puf_2015.csv
+            demographics_2015.csv
+  model_data/
+    Compiled-SOI-Tables/
+    Macro-Projections/
+  raw_data/
+    CPS-ASEC/
+    DINA/
+    SCF/
+    SIPP/
+```
+
+The public repositories document the required modeling components, but the full
+dependency bundle is not assembled inside this repo. In practice, a standalone
+run needs the 2015 IRS PUF plus the additional inputs referenced by the
+baseline runscript.
+
 ## Outstanding tasks
 As we focus on building a usable PUF for Budget Lab launch products, we are tabling several nice-but-not-strictly-necessary features for future versions. These include:  
 - Unpacking aggregate return

--- a/src/configure.R
+++ b/src/configure.R
@@ -8,9 +8,19 @@
 # Read runscript
 #----------------
 
-runscript_id = 'baseline'
+runscript_id = Sys.getenv('TAX_DATA_RUNSCRIPT_ID', unset = 'baseline')
 runscript = file.path('./config/runscripts', paste0(runscript_id, '.yaml')) %>% 
   read_yaml()
+
+write_locally_override = Sys.getenv('TAX_DATA_WRITE_LOCALLY', unset = '')
+if (write_locally_override != '') {
+  runscript$runtime_options$write_locally = tolower(write_locally_override) %in% c('1', 'true', 't', 'yes', 'y')
+}
+
+user_id_override = Sys.getenv('TAX_DATA_USER_ID', unset = '')
+if (user_id_override != '') {
+  runscript$runtime_options$user_id = user_id_override
+}
 
 
 #-----------------
@@ -20,6 +30,17 @@ runscript = file.path('./config/runscripts', paste0(runscript_id, '.yaml')) %>%
 # Read versioning info
 output_roots       = read_yaml('./config/interfaces/output_roots.yaml')
 interface_versions = read_yaml('./config/interfaces/interface_versions.yaml')
+
+# Allow local path overrides without editing tracked config files
+local_root_override = Sys.getenv('TAX_DATA_LOCAL_ROOT', unset = '')
+if (local_root_override != '') {
+  output_roots$local = local_root_override
+}
+
+production_root_override = Sys.getenv('TAX_DATA_PRODUCTION_ROOT', unset = '')
+if (production_root_override != '') {
+  output_roots$production = production_root_override
+}
 
 # Get current date/time to vintage this run
 vintage = format(Sys.time(), '%Y%m%d%H')
@@ -33,6 +54,18 @@ if (runscript$runtime_options$write_locally) {
   output_root = file.path(output_roots$local, runscript$runtime_options$user_id)
 } else {
   output_root = output_roots$production
+}
+
+# Resolve dependency reads from the active run context by default. Public/local
+# users can also supply an explicit input root when keeping inputs separate
+# from outputs.
+dependency_root_override = Sys.getenv('TAX_DATA_INPUT_ROOT', unset = '')
+if (dependency_root_override != '') {
+  dependency_root = dependency_root_override
+} else if (runscript$runtime_options$write_locally) {
+  dependency_root = output_roots$local
+} else {
+  dependency_root = output_roots$production
 }
 
 # Set output path
@@ -83,7 +116,7 @@ interface_versions %>%
 interface_paths = interface_versions %>% 
   map2(.y = names(.),
        .f = ~ file.path(
-         output_roots$production,
+         dependency_root,
          .x$type,
          .y,
          paste0('v', .x$version), 


### PR DESCRIPTION
This PR fixes the local/standalone path-resolution bug tracked in #26.

Closes #26.

What changed:
- allow the runscript id to be overridden via `TAX_DATA_RUNSCRIPT_ID`
- allow `write_locally` and `user_id` to be overridden via env vars for local runs
- allow local and production roots to be overridden without editing tracked config files
- resolve dependency inputs from the active run context instead of always using `output_roots$production`
- document the local standalone env vars and expected directory layout in `README.md`

Why:
- before this change, `write_locally: True` only changed where outputs were written
- dependency reads still resolved from `output_roots$production`, which made local standalone execution brittle and tied to the internal Yale filesystem layout

Verification:
- staged local `IRS-PUF` inputs under a local root
- ran `TAX_DATA_WRITE_LOCALLY=1 TAX_DATA_USER_ID=user_test TAX_DATA_LOCAL_ROOT=/tmp/tax-data-root Rscript src/main.R`
- confirmed the repo now reads dependencies from the local root and advances to the next external missing-input error (`Compiled-SOI-Tables`) instead of failing on the hardcoded production-root assumption
